### PR TITLE
pairing: pass device model and features to HomePod mini

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -170,6 +170,8 @@ async fn start_streaming(
     port: Option<u16>,
     name: Option<String>,
     volume: Option<f32>,
+    model: Option<String>,
+    features: Option<String>,
     state: State<'_, StreamingState>,
 ) -> Result<StreamingInfo, String> {
     use audio_capture::CaptureFormat;
@@ -199,8 +201,8 @@ async fn start_streaming(
         port,
         name: display_name.clone(),
         mac: None,
-        model: None,
-        features: None,
+        model,
+        features,
     };
     let stream_handle = open_live_stream(descriptor, volume)
         .await
@@ -334,6 +336,8 @@ async fn connect_device(
     ip: String,
     port: Option<u16>,
     name: Option<String>,
+    model: Option<String>,
+    features: Option<String>,
     state: State<'_, ConnectionState>,
 ) -> Result<ConnectionInfo, String> {
     let parsed: IpAddr = ip.parse().map_err(|e| format!("IP inválida '{ip}': {e}"))?;
@@ -345,8 +349,8 @@ async fn connect_device(
         port,
         name: display_name.clone(),
         mac: None,
-        model: None,
-        features: None,
+        model,
+        features,
     };
 
     // Si ya había una sesión previa, la soltamos antes de abrir otra.

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -81,6 +81,8 @@ async function connect(device: Device) {
       ip,
       port: device.port,
       name: device.name,
+      model: device.model,
+      features: device.features,
     });
     connectedId = device.id;
   } catch (err) {
@@ -137,6 +139,8 @@ async function startPlay() {
       port: dev.port,
       name: dev.name,
       volume: vol,
+      model: dev.model,
+      features: dev.features,
     });
     playing = true;
     playerStatus.textContent = t("player_playing");


### PR DESCRIPTION
Pass discovered device model and features from mDNS to the pairing code, ensuring device-specific capabilities are correctly used. This fixes HomePod mini failing to pair due to missing device characteristics.

- Update connect_device and start_streaming to accept optional model and features
- Pass these parameters from UI to backend Tauri commands
- Ensures airplay2-rs receives correct device info during pair-setup

Fixes silent pairing failure on HomePod mini.